### PR TITLE
Added  RSTUF API updates after every local pypi update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # PyPI Mirror Update
-This maintains a local mirror of packages from PyPI by downloading and updating the package index 
+
+This project helps maintain a local mirror of packages from PyPI, which is then synchronized with RSTUF (<rstuf url>). The process involves an initial synchronization of the mirror, followed by the generation of a CSV file that is used for the initial RSTUF bootstrapping. The generated CSV contains metadata about the packages in the PyPI mirror directory, such as the relative path, length, hash algorithm, and hash.
+
+## Initial Bootstrapping
+
+To perform the initial bootstrapping, follow these steps:
+
+1. **Mirror the Index Locally**:
+   Run the following command to mirror the PyPI index locally:
+   ```sh
+   python pypi_mirror.py
+   ```
+   Since this is the first synchronization (i.e., the mirror does not exist locally), this command will create the local mirror with the following structure:
+
+   ```
+   ├── pypi-index-mirror
+   │   ├── pypi_mirror
+   │   │   ├── index.html
+   │   │   └── simple
+   │   │       ├── <package-name>
+   │   │       │   ├── index.html
+   ```
+
+   - `index.html` (global, inside `pypi_mirror/`) – Lists all available packages in the mirror.
+   - `simple/<package-name>/index.html` – Lists available versions of a specific package.
+
+2. **Generate the CSV for Initial Bootstrapping**:
+   Run the following command to generate a CSV file of the local mirror, which will be used for the initial bootstrapping:
+   ```sh
+   python3 generate_csv.py
+   ```
+
+## Subsequent Updates
+
+After the initial bootstrapping, the process involves two main functions: checking for changelog events from PyPI since the last synchronization and updating RSTUF accordingly. It handles changelog events as follows:
+- `'new'`, `'add'`, `'create'`, `'update'`, `'docupdate'`: Downloads or updates the package on RSTUF.
+- `'remove'`: Deletes the package from RSTUF.
+- `'rename'`: Deletes the old package and then downloads or updates the renamed package.
+
+To fetch changes and update the local mirror, follow these steps:
+
+1. **Fetch Changes**:
+   Run the following command to check for changelog events, update the local mirror, and send add/remove requests to RSTUF accordingly:
+   ```sh
+   python pypi_mirror.py
+   ```
+   If the local mirror already exists, the script will assume it is an update and will check for changelog events, update the local mirror, and send appropriate requests to RSTUF

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyPI Mirror Update
 
-This project helps maintain a local mirror of packages from PyPI, which is then synchronized with RSTUF (<rstuf url>). The process involves an initial synchronization of the mirror, followed by the generation of a CSV file that is used for the initial RSTUF bootstrapping. The generated CSV contains metadata about the packages in the PyPI mirror directory, such as the relative path, length, hash algorithm, and hash.
+This project helps maintain a local mirror of packages from PyPI, which is then synchronized with RSTUF following the [Repository Service for TUF Guide](https://repository-service-tuf.readthedocs.io/en/stable/guide/general/usage.html). The process involves an initial synchronization of the mirror, followed by the generation of a CSV file that is used for the initial RSTUF bootstrapping. The generated CSV contains metadata about the packages in the PyPI mirror directory, such as the relative path, length, hash algorithm, and hash.
 
 ## Initial Bootstrapping
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,0 +1,2 @@
+[settings]
+RSTUF_API_BASE_URL = http://rstuf.local/api/v1

--- a/generate_csv.py
+++ b/generate_csv.py
@@ -5,10 +5,11 @@ import hashlib
 
 mirror_dir = 'pypi_mirror'
 
-HASH_ALGORITHM = "sha256"
+HASH_ALGORITHM = "blake2b"
+HASH_LENGTH = 32
 
 def digest(to_hash:bytes) -> bytes:
-        return hashlib.sha256(to_hash).hexdigest()
+        return hashlib.blake2b(to_hash, digest_size=HASH_LENGTH).hexdigest()
 
 def compute_hash_and_length(file_path):
     try:
@@ -37,7 +38,7 @@ def generate_all_csv(mirror_dir, output_csv):
                 rows.append({
                     'path': relative_path,
                     'length': file_length,
-                    'hash_algorithm': f'{HASH_ALGORITHM}',
+                    'hash_algorithm': f'{HASH_ALGORITHM}-{HASH_LENGTH}',
                     'hash': file_hash
                 })
 

--- a/generate_csv.py
+++ b/generate_csv.py
@@ -11,6 +11,9 @@ HASH_LENGTH = 32
 def digest(to_hash:bytes) -> bytes:
         return hashlib.blake2b(to_hash, digest_size=HASH_LENGTH).hexdigest()
 
+def hash_algorithm_str() -> str:
+    return f"{HASH_ALGORITHM}-{HASH_LENGTH}"
+
 def compute_hash_and_length(file_path):
     try:
         with open(file_path, 'rb') as f:
@@ -28,19 +31,9 @@ def generate_all_csv(mirror_dir, output_csv):
     """
     rows = []
 
-    for root, _, files in os.walk(mirror_dir):
-        for file in files:
-            file_path = os.path.join(root, file)
-            relative_path = os.path.relpath(file_path, mirror_dir)
-            file_hash, file_length = compute_hash_and_length(file_path)
-            
-            if file_hash is not None and file_length is not None:
-                rows.append({
-                    'path': relative_path,
-                    'length': file_length,
-                    'hash_algorithm': f'{HASH_ALGORITHM}-{HASH_LENGTH}',
-                    'hash': file_hash
-                })
+    simple_dir = os.path.join(mirror_dir, 'simple')
+    updated_pkg = [pkg for pkg in os.listdir(simple_dir) if os.path.isdir(os.path.join(simple_dir, pkg))]
+    rows = generate_updated_csv(updated_pkg)
 
     with open(output_csv, 'w', newline='', encoding='utf-8') as csvfile:
         fieldnames = ['path', 'length', 'hash_algorithm', 'hash']
@@ -51,14 +44,17 @@ def generate_all_csv(mirror_dir, output_csv):
     print(f"CSV generated at {output_csv}")
 
 
-def generate_updated_csv(updated_pkg, output_csv):
+def generate_updated_csv(updated_pkg):
     """
     Computes hashes and lengths for updated packages
     """
+    # simple/index.html is always updated
+    updated_pkg.add('') #root simple directory
+
     rows = []
 
     for pkg_name in updated_pkg:
-        pkg_dir = os.path.join(mirror_dir, 'simple', pkg_name)
+        pkg_dir = os.path.join(mirror_dir, 'simple', pkg_name) if pkg_name else mirror_dir
         file_hash, file_length = compute_hash_and_length(os.path.join(pkg_dir, 'index.html'))
         relative_path = os.path.relpath(pkg_dir, mirror_dir)
             
@@ -66,16 +62,9 @@ def generate_updated_csv(updated_pkg, output_csv):
             rows.append({
                 'path': relative_path,
                 'length': file_length,
-                'hash_algorithm': f'{HASH_ALGORITHM}',
+                'hash_algorithm': hash_algorithm_str(),
                 'hash': file_hash
             })
-
-    # with open(output_csv, 'w', newline='', encoding='utf-8') as csvfile:
-    #     fieldnames = ['path', 'length', 'hash_algorithm', 'hash']
-    #     writer = csv.DictWriter(csvfile, fieldnames=fieldnames, delimiter=';')
-    #     writer.writeheader()
-    #     writer.writerows(rows)
-    
     return rows
 
 

--- a/generate_csv.py
+++ b/generate_csv.py
@@ -5,7 +5,7 @@ import hashlib
 
 mirror_dir = 'pypi_mirror'
 
-HASH_ALGORITHM = "SHA-256"
+HASH_ALGORITHM = "sha256"
 
 def digest(to_hash:bytes) -> bytes:
         return hashlib.sha256(to_hash).hexdigest()
@@ -21,7 +21,7 @@ def compute_hash_and_length(file_path):
         return None, None
 
 
-def generate_csv(mirror_dir, output_csv):
+def generate_all_csv(mirror_dir, output_csv):
     """
     Walks through the mirror directory, computes hashes and lengths for each file, and writes the data to a CSV.
     """
@@ -50,6 +50,34 @@ def generate_csv(mirror_dir, output_csv):
     print(f"CSV generated at {output_csv}")
 
 
+def generate_updated_csv(updated_pkg, output_csv):
+    """
+    Computes hashes and lengths for updated packages
+    """
+    rows = []
+
+    for pkg_name in updated_pkg:
+        pkg_dir = os.path.join(mirror_dir, 'simple', pkg_name)
+        file_hash, file_length = compute_hash_and_length(os.path.join(pkg_dir, 'index.html'))
+        relative_path = os.path.relpath(pkg_dir, mirror_dir)
+            
+        if file_hash is not None and file_length is not None:
+            rows.append({
+                'path': relative_path,
+                'length': file_length,
+                'hash_algorithm': f'{HASH_ALGORITHM}',
+                'hash': file_hash
+            })
+
+    # with open(output_csv, 'w', newline='', encoding='utf-8') as csvfile:
+    #     fieldnames = ['path', 'length', 'hash_algorithm', 'hash']
+    #     writer = csv.DictWriter(csvfile, fieldnames=fieldnames, delimiter=';')
+    #     writer.writeheader()
+    #     writer.writerows(rows)
+    
+    return rows
+
+
 if __name__ == '__main__':
     output_csv_path = os.path.join(mirror_dir, 'mirror_metadata.csv')
-    generate_csv(mirror_dir, output_csv_path)
+    generate_all_csv(mirror_dir, output_csv_path)

--- a/pypi_mirror.py
+++ b/pypi_mirror.py
@@ -3,6 +3,9 @@ import requests
 from bs4 import BeautifulSoup
 from multiprocessing import Pool, cpu_count
 import xmlrpc.client
+import shutil
+from generate_csv import generate_updated_csv
+from rstuf import send_add_requests, send_remove_requests
 
 base_url = "https://pypi.org/simple/"
 mirror_dir = 'pypi_mirror'
@@ -20,7 +23,7 @@ def download_root_index():
         return None
 
 def fetch_package_index(args):
-    """fetch and save the index for an individual package"""
+    """download from pypi and save the index for an individual package"""
     base_url, package_name, mirror_dir = args
     package_url = base_url + package_name
     try:
@@ -39,7 +42,7 @@ def fetch_package_index(args):
         print(f"Unexpected error fetching index for {package_name}: {e}")
 
 def get_local_packages():
-    """get a set of locally stored packages"""
+    """get locally stored packages"""
     simple_dir = os.path.join(mirror_dir, "simple")
     return set(os.listdir(simple_dir)) if os.path.exists(simple_dir) else set()
 
@@ -58,26 +61,86 @@ def are_all_pkgs_downloaded(local_index_path):
 
 
 def update_mirror():
-    """update local mirror with recent events from pypi"""
+    """
+    Handles changelog events as follows:
+    - 'new', 'add', 'create', 'update', 'docupdate': Downloads/updates the pkg
+    - 'remove': Deletes the package dir
+    - 'rename': Deletes the old repository, then downloads/updates the renamed pkg
+    """
     with open(last_serial_path, 'r') as f:
         serial = int(f.readline().split(":")[1].strip())
 
-    packages, current_serial = set(), client.changelog_last_serial()
-    # changelog_since_serial(serial) return only 50k changes per query and the returned numbers 
+    current_serial = client.changelog_last_serial()
+
+    pkgs_to_download, pkgs_to_remove = get_changes(serial, current_serial)
+
+    print(f"Removing {len(pkgs_to_remove)}, Adding {len(pkgs_to_download)} pkgs" )
+
+    handle_removals(pkgs_to_remove)
+    handle_downloads(pkgs_to_download)
+    
+    if pkgs_to_download:
+        artifacts_metadata = generate_updated_csv(pkgs_to_download, os.path.join(mirror_dir, 'mirror_metadata.csv'))
+        send_add_requests(artifacts_metadata)
+    
+    if pkgs_to_remove:
+        removed_artifacts = [ os.path.join("simple", package) for package in pkgs_to_remove]
+        send_remove_requests(removed_artifacts)
+    
+    with open(last_serial_path, 'w') as f:
+        f.write(f"Last Serial: {serial}")
+
+
+def get_changes(serial, current_serial):
+    """Process changelog entries and categorize packages by events
+        Change events are: 'add', 'create', 'new', 'rename', 'remove', 'update', 'docupdate' """
+    packages_to_download = set()
+    packages_to_remove = set()
+
+    # nb: changelog_since_serial(serial) returns only 50k changes per query
     while serial < current_serial:
         changes = client.changelog_since_serial(serial)
         if not changes: break
-        packages.update(row[0] for row in changes)
+
+        for change in changes:
+            package_name = change[0]
+            event = change[3].split(" ")[0] 
+
+            if event in {"new", "add", "create", "update", "docupdate"}:
+                packages_to_download.add(package_name)
+            elif event == "remove":
+                packages_to_remove.add(package_name)
+            elif event == "rename":
+                old_name = change[3].split("rename from ")[1].strip()
+                packages_to_remove.add(old_name)
+                packages_to_download.add(package_name)
+
         serial = changes[-1][-1]
 
+    return packages_to_download, packages_to_remove
+
+
+def handle_removals(packages):
+    """remove packages from the local mirror"""
+    for package in packages:
+        package_dir = os.path.join(mirror_dir, "simple", package)
+        if os.path.exists(package_dir):
+            try:
+                shutil.rmtree(package_dir)
+                print(f"Removed {package}")
+            except Exception as e:
+                print(f"Error removing {package}: {e}")
+
+
+def handle_downloads(packages):
+    """download packages in the local mirror"""
     if packages:
         print(f"Updating {len(packages)} packages...")
         with Pool(cpu_count()) as pool:
             pool.map(fetch_package_index, [(base_url, p, mirror_dir) for p in packages])
-        with open(last_serial_path, 'w') as f:
-            f.write(f"Last Serial: {serial}")
     else:
-        print("No new changes to update.")
+        print("No new update to add")
+
 
 def main():
     local_index_path = os.path.join(mirror_dir, "index.html")
@@ -127,7 +190,6 @@ def initialize_mirror(local_index_path):
         with Pool(num_workers) as pool:
             pool.map(fetch_package_index, tasks_arg)
 
-        # save the last serial if set
         if serial:
             with open(last_serial_path, 'w') as f:
                 f.write(f"Last Serial: {serial}")

--- a/pypi_mirror.py
+++ b/pypi_mirror.py
@@ -72,7 +72,7 @@ def update_mirror():
 
     current_serial = client.changelog_last_serial()
 
-    pkgs_to_download, pkgs_to_remove = get_changes(serial, current_serial)
+    pkgs_to_download, pkgs_to_remove, last_serial = get_changes(serial, current_serial)
 
     print(f"Removing {len(pkgs_to_remove)}, Adding {len(pkgs_to_download)} pkgs" )
 
@@ -88,7 +88,7 @@ def update_mirror():
         send_remove_requests(removed_artifacts)
     
     with open(last_serial_path, 'w') as f:
-        f.write(f"Last Serial: {serial}")
+        f.write(f"Last Serial: {last_serial}")
 
 
 def get_changes(serial, current_serial):
@@ -117,7 +117,7 @@ def get_changes(serial, current_serial):
 
         serial = changes[-1][-1]
 
-    return packages_to_download, packages_to_remove
+    return packages_to_download, packages_to_remove, serial
 
 
 def handle_removals(packages):
@@ -148,7 +148,7 @@ def main():
     needs_initialization = (
         not os.path.exists(local_index_path)
         or not os.path.exists(last_serial_path)
-        or not are_all_pkgs_downloaded(local_index_path)
+        # or not are_all_pkgs_downloaded(local_index_path)
     )
 
     if needs_initialization:

--- a/rstuf.py
+++ b/rstuf.py
@@ -1,7 +1,12 @@
 import requests
 import json
+import configparser
+import os
 
-RSTUF_API_BASE_URL = "http://rstuf.local/api/v1"
+config = configparser.ConfigParser()
+config.read(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config', 'config.ini'))
+
+RSTUF_API_BASE_URL = config.get("settings", "RSTUF_API_BASE_URL")
 ARTIFACTS_ADD_URL = f"{RSTUF_API_BASE_URL}/artifacts"
 ARTIFACTS_DELETE_URL = f"{RSTUF_API_BASE_URL}/artifacts/delete"
 

--- a/rstuf.py
+++ b/rstuf.py
@@ -1,0 +1,34 @@
+import requests
+
+RSTUF_API_BASE_URL = "https://repository-service-tuf.github.io/api/v1"
+ARTIFACTS_ADD_URL = f"{RSTUF_API_BASE_URL}/artifacts"
+ARTIFACTS_DELETE_URL = f"{RSTUF_API_BASE_URL}/artifacts/delete"
+
+def send_add_requests(artifacts):
+    payload = {"artifacts": []}
+
+    for artifact in artifacts:
+        payload["artifacts"].append({
+            "info": {
+                "length": artifact["length"],
+                "hashes": {artifact["hash_algorithm"]: artifact["hash"]},
+                "custom": {"key": "value"},
+            },
+            "path": artifact["path"],
+        })
+
+    response = requests.post(ARTIFACTS_ADD_URL, json=payload)
+    if response.status_code == 200:
+        print(f"Successfully added {len(artifacts)} artifacts.")
+    else:
+        print(f"Error adding artifacts: {response.status_code}, {response.text}")
+
+
+def send_remove_requests(paths):
+    payload = {"artifacts": paths}
+    response = requests.post(ARTIFACTS_DELETE_URL, json=payload)
+
+    if response.status_code == 200:
+        print(f"Successfully removed {len(paths)} artifacts.")
+    else:
+        print(f"Error removing artifacts: {response.status_code}, {response.text}")

--- a/rstuf.py
+++ b/rstuf.py
@@ -1,6 +1,7 @@
 import requests
+import json
 
-RSTUF_API_BASE_URL = "https://repository-service-tuf.github.io/api/v1"
+RSTUF_API_BASE_URL = "http://rstuf.local/api/v1"
 ARTIFACTS_ADD_URL = f"{RSTUF_API_BASE_URL}/artifacts"
 ARTIFACTS_DELETE_URL = f"{RSTUF_API_BASE_URL}/artifacts/delete"
 
@@ -18,8 +19,9 @@ def send_add_requests(artifacts):
         })
 
     response = requests.post(ARTIFACTS_ADD_URL, json=payload)
-    if response.status_code == 200:
-        print(f"Successfully added {len(artifacts)} artifacts.")
+    if response.status_code == 202:
+        task_id = json.loads(response.text).get("data", {}).get("task_id")
+        print(f"Successfully submitted {len(artifacts)} artifacts to be added.(Task ID: {task_id})")
     else:
         print(f"Error adding artifacts: {response.status_code}, {response.text}")
 
@@ -28,7 +30,8 @@ def send_remove_requests(paths):
     payload = {"artifacts": paths}
     response = requests.post(ARTIFACTS_DELETE_URL, json=payload)
 
-    if response.status_code == 200:
-        print(f"Successfully removed {len(paths)} artifacts.")
+    if response.status_code == 202:
+        task_id = json.loads(response.text).get("data", {}).get("task_id")
+        print(f"Successfully submitted {len(paths)} artifacts to be removed. (Task ID: {task_id})")
     else:
         print(f"Error removing artifacts: {response.status_code}, {response.text}")


### PR DESCRIPTION
This implements the below:
> Please prepare a script to call the RSTUF API  for adding/updating/removing new/modified/deleted simple indices since the last sync with PyPI
- Added sync with RSTUF API after every local mirror update
- Updated `generate_csv` to produce metadata for updated packages only
